### PR TITLE
Add mising `--cap-add` in example commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ just fine.
 ## How do I run it?
 Run something like:
 ```bash
-docker run --net=host -e DHCP_RANGE_START=192.168.0.1 samdbmg/dhcp-netboot.xyz
+docker run --net=host --cap-add=NET_ADMIN -e DHCP_RANGE_START=192.168.0.1 samdbmg/dhcp-netboot.xyz
 ```
 Make sure you adjust the IP address in `DHCP_RANGE_START` to the first address
 on your network. dnsmasq will automatically figure out the right subnet mask to

--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ downloaded from the Internet as needed.
 To play DHCP server, the container needs listen to broadcasts on the target
 network, which doesn't seem to work with port forwarding.
 
+### Firewall
+Don't forget, if you've got a firewall running on your system you'll need to
+allow UDP traffic to ports 67 (DHCP), 69 (TFTP) and 4011 (PXE), along with
+TCP port 80 (HTTP) for the built in webserver. For `ufw`, try:
+```bash
+sudo ufw allow proto udp from any to any port 67
+sudo ufw allow proto udp from any to any port 69
+sudo ufw allow proto udp from any to any port 4011
+sudo ufw allow proto tcp from any to any port 80
+```
+Don't forget to remove the rules when you're done!
+
 ## Demo
 The [vagrant-demo/](vagrant-demo/) directory contains a demo of this container
 using a Virtualbox VM managed by Vagrant, bridged onto your host network. To

--- a/vagrant-demo/run-demo.sh
+++ b/vagrant-demo/run-demo.sh
@@ -3,7 +3,7 @@
 DHCP_RANGE_START=${1:-192.168.0.1}
 
 # Start the netboot container and run it in the background
-docker run --net=host -e DHCP_RANGE_START=${DHCP_RANGE_START} samdbmg/dhcp-netboot.xyz &
+docker run --net=host --cap-add=NET_ADMIN -e DHCP_RANGE_START=${DHCP_RANGE_START} samdbmg/dhcp-netboot.xyz &
 DOCKER_PROCESS=$!
 
 # Catch ctrl-c and clean up


### PR DESCRIPTION
Adds missing NET_ADMIN capability in example commands.
Also mentions firewall holes in the README, since it took me a while to spot why it didn't work on a different machine!

Fixes #1 