### PR TITLE
Fix loading menus locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
         ipv4_address: ${CONTAINER_IP:-192.168.0.250}
     cap_add:
       - NET_ADMIN
+    volumes:
+      - /config
 networks:
   netbootxyz_network:
     driver: ipvlan

--- a/etc/dnsmasq.conf
+++ b/etc/dnsmasq.conf
@@ -8,22 +8,18 @@ log-dhcp
 # option space. That's to avoid confusing some old or broken DHCP clients.
 dhcp-no-override
 
-# Identify the type of PXE client, and set the boot filename accordingly
-# Copied from https://github.com/linuxserver/docker-netbootxyz#dd-wrt
-dhcp-match=set:bios,60,PXEClient:Arch:00000
-dhcp-boot=tag:bios,netboot.xyz-undionly.kpxe
-dhcp-match=set:efi32,60,PXEClient:Arch:00002
-dhcp-boot=tag:efi32,netboot.xyz.efi
-dhcp-match=set:efi32-1,60,PXEClient:Arch:00006
-dhcp-boot=tag:efi32-1,netboot.xyz.efi
-dhcp-match=set:efi64,60,PXEClient:Arch:00007
-dhcp-boot=tag:efi64,netboot.xyz.efi
-dhcp-match=set:efi64-1,60,PXEClient:Arch:00008
-dhcp-boot=tag:efi64-1,netboot.xyz.efi
-dhcp-match=set:efi64-2,60,PXEClient:Arch:00009
-dhcp-boot=tag:efi64-2,netboot.xyz.efi
+# send disable multicast and broadcast discovery, and to download the boot file immediately
+# DHCP_PXE_DISCOVERY_CONTROL, should be vendor option? Needs more understanding and source
+dhcp-option=vendor:PXEClient,6,2b
 
-# Boot the relevant PXE image
-pxe-service=x86PC,"Run netboot.xyz, BIOS mode",netboot.xyz-undionly.kpxe
-pxe-service=X86-64_EFI, "Run netboot.xyz, UEFI mode", netboot.xyz.efi
-pxe-service=BC_EFI, "Run netboot.xyz, UEFI mode", netboot.xyz.efi
+
+# Detect whether this is an iPXE dhcp request, or an initial boot
+dhcp-match=set:ipxe-bios,175,33
+dhcp-match=set:ipxe-efi,175,36
+
+# For initial boot, just provide the file
+pxe-service=tag:!ipxe-ok,X86PC,PXE,netboot.xyz-undionly.kpxe
+pxe-service=tag:!ipxe-ok,BC_EFI,PXE,netboot.xyz.efi
+pxe-service=tag:!ipxe-ok,X86-64_EFI,PXE,netboot.xyz.efi
+
+# The DHCP request case is handled on the command line for dnsmasq, because it requires the container IP

--- a/etc/services.d/dnsmasq/run
+++ b/etc/services.d/dnsmasq/run
@@ -1,3 +1,12 @@
 #!/usr/bin/with-contenv bash
 
-dnsmasq --no-daemon --dhcp-range=${DHCP_RANGE_START},proxy ${DNSMASQ_ARGS}
+if [ -z ${CONTAINER_IP} ]; then
+    # If an IP wasn't given, assume the default route is the one to go for and get IP from that
+    CONTAINER_IP=$(ip route get to 1.1.1.1 | awk '/1.1.1.1/ { print $7}')
+fi
+
+# Start dnsmasq
+dnsmasq --no-daemon --dhcp-range=${DHCP_RANGE_START},proxy \
+    --dhcp-boot=tag:ipxe-bios,netboot.xyz.kpxe,,${CONTAINER_IP} \
+    --dhcp-boot=tag:ipxe-efi,netboot.xyz.efi,,${CONTAINER_IP} \
+    ${DNSMASQ_ARGS}


### PR DESCRIPTION
Reworks the dnsmasq config to correctly set the `next-server` and make sure one of the `isset` tests [here](https://github.com/netbootxyz/netboot.xyz/blob/54ef62ff54aab0143ffa4b4c00bb533d62c380c9/roles/netbootxyz/templates/disks/netboot.xyz.j2#L40-L45) succeeds instead of falling back to the menus hosted by netboot.xyz

Tested with a BIOS and a UEFI VM locally, confirmed that the next server gets set and I can change the `win_base_url` in boot.cfg and have that work as well.

Fixes #6
Fixes #7